### PR TITLE
Fixing the ``/demo``

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Fancy Emitter Demo</title>
-  <script type="module" src="../dist/esm/demo/index.js"></script>
+  <!-- Uncomment for local testing --> 
+  <!--<script type="module" src="../dist/esm/demo/index.js"></script>-->
+  <!-- Comment for local testing -->
+  <script type="module" src="//unpkg.com/fancy-emitter/dist/esm/index.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Hi Maurice
The ``/dist`` folder is not tracked by master ( which is good ) so the esm bundle can't be loaded with a relative path.

Best regards